### PR TITLE
Set the contents of /etc/mailname correctly

### DIFF
--- a/roles/email/tasks/main.yml
+++ b/roles/email/tasks/main.yml
@@ -10,6 +10,9 @@
   template: src=update-exim4.conf.conf.j2 dest=/etc/exim4/update-exim4.conf.conf
   notify: restart exim
 
+- name: Update /etc/mailname
+  copy: content="{{ incoming_email_host }}\n" dest=/etc/mailname
+
 - name: Run update-exim4.conf
   shell: update-exim4.conf
   notify: restart exim


### PR DESCRIPTION
Use the `{{ incoming_email_host }}` variable as the contents of
/etc/mailname.
