### PR TITLE
Make sure the default character set for the database is UTF-8

### DIFF
--- a/roles/db/tasks/main.yml
+++ b/roles/db/tasks/main.yml
@@ -12,7 +12,7 @@
   service: name=mysql state=started enabled=yes
 
 - name: Ensure database is created
-  mysql_db: name={{ db_name }} state=present
+  mysql_db: name={{ db_name }} state=present encoding=utf8
 
 - name: Ensure user has access to the database
   mysql_user: name={{ db_user }} password={{ db_password }} state=present priv={{ db_name }}.*:ALL


### PR DESCRIPTION
The default character set for MySQL database is still latin1 with a
default collation of latin1_swedish_ci.  When creating the new database
specifying a character set of 'utf8' should ensure that the character
set of the tables and columns created is also UTF-8.  (With the
character set of a column as latin1, you can't store Farsi text, for
instance.)

This will only affect newly provisioned sites. I didn't want to run these
commands on the staging site out-of-hours, but it should be possible
to change the character sets of the existing database, tables and
columns with (after backing up the data, in case anything goes wrong)
something like: http://stackoverflow.com/a/11873492/223092
