### PR TITLE
Update celery invocation, and set ALLOWED_HOSTS regardless of DEBUG

### DIFF
--- a/roles/celery/templates/celery_beat_start.j2
+++ b/roles/celery/templates/celery_beat_start.j2
@@ -9,4 +9,4 @@ cd $DJANGODIR
 
 # Programs meant to be run under supervisor should not daemonize themselves
 # (do not use --daemon).
-exec python manage.py celery beat
+exec celery -A writeit beat

--- a/roles/celery/templates/celery_worker_start.j2
+++ b/roles/celery/templates/celery_worker_start.j2
@@ -9,4 +9,4 @@ cd $DJANGODIR
 
 # Programs meant to be run under supervisor should not daemonize themselves
 # (do not use --daemon).
-exec python manage.py celery worker --concurrency={{ celery_num_workers }}
+exec celery -A writeit worker --concurrency={{ celery_num_workers }}

--- a/roles/web/templates/local_settings.py.j2
+++ b/roles/web/templates/local_settings.py.j2
@@ -8,9 +8,9 @@ TEMPLATE_DEBUG = True
 DEBUG = False
 TASTYPIE_FULL_DEBUG = False
 TEMPLATE_DEBUG = False
+{% endif %}
 
 ALLOWED_HOSTS = ['.{{ nginx_server_name }}']
-{% endif %}
 
 TIME_ZONE = 'Asia/Tehran'
 


### PR DESCRIPTION
This branch has changes to go along with the upgrade of our Alpaca
instance of WriteInPublic to Django 1.8, to go with this branch:

* https://github.com/ciudadanointeligente/write-it/tree/alpaca-rebased-django-1.8

The upgrade of WriteIt to Django 1.8 required an upgrade to Celery, to
version 3.1.25. With this version of Celery, one no longer invokes
the celery worker and celery beat process via "./manage.py" commands,
which were supplied by django-celery.  Now they should be invoked with
the celery script.

In addition, with Django 1.8, ALLOWED_HOST must be correctly set
even when `DEBUG = True`.