### PR TITLE
Get nginx to reject requests with invalid Host headers

### DIFF
--- a/roles/nginx/templates/writeit.j2
+++ b/roles/nginx/templates/writeit.j2
@@ -1,3 +1,35 @@
+# If there's no default_server explicitly specified, then the first
+# server block in the configuration (across all the servers included
+# in sites-available) will be used as the default. We don't want the
+# default server to be the actual site because then Django has to deal
+# with tons of malicious requests with bad Host headers that generate
+# error emails, consume resources, and could be filtered out by nginx.
+#
+# These server blocks with default_server will return Nginx's special
+# 444 code to mean close the connection without a response.
+
+server {
+    listen 80 default_server;
+    return 444;
+}
+
+server {
+    listen 443 default_server;
+    # Note that we do need a certificate here so that the SSL handshake
+    # can be done and the Host header examined. The host won't match
+    # the certificate (or it would be handled by the server block below
+    # with the server_name match) but that doesn't matter - this is
+    # just present to allow us to close the connection for requests
+    # with unknown Host headers.
+    ssl on;
+    ssl_certificate {{ ssl_dest_dir }}/{{ application_name }}.crt;
+    ssl_certificate_key {{ ssl_dest_dir }}/{{ application_name }}.key;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
+    ssl_prefer_server_ciphers on;
+    return 444;
+}
+
 upstream {{ application_name }}_wsgi_server {
   # fail_timeout=0 means we always retry an upstream even if it failed
   # to return a good HTTP response (in case the Unicorn master nukes a


### PR DESCRIPTION
At the moment we get a lot of error emails from Django about requests
with disallowed Host headers. There's no need for Django to even know
about this, since we can filter them out using Nginx, meaning the
server is doing much less work to handle such malicious or malformed
requests.